### PR TITLE
Add DeepAlpha to Financial Data and Trading section

### DIFF
--- a/README.md
+++ b/README.md
@@ -976,6 +976,7 @@ Tutorial on using cvxpy: [1](https://calmcode.io/cvxpy-one/the-stigler-diet.html
 [findatapy](https://github.com/cuemacro/findatapy) - Read stock data from various sources.  
 [ta](https://github.com/bukosabino/ta) - Technical analysis library.  
 [backtrader](https://github.com/mementum/backtrader) - Backtesting for trading strategies.  
+[deepalpha](https://github.com/stefanoviana/deepalpha) - AI crypto trading bot with ML ensemble (LightGBM + XGBoost), 12 exchanges, Telegram bot.  
 [surpriver](https://github.com/tradytics/surpriver) - Find high moving stocks before they move using anomaly detection and machine learning.  
 [ffn](https://github.com/pmorissette/ffn) - Financial functions.  
 [bt](https://github.com/pmorissette/bt) - Backtesting algorithms.  


### PR DESCRIPTION
## What is DeepAlpha?

[DeepAlpha](https://github.com/stefanoviana/deepalpha) is an open-source AI crypto trading bot built with Python. It uses ML ensemble models (LightGBM + XGBoost) for market prediction.

### Key Features
- ML ensemble (LightGBM + XGBoost) with 72 engineered features
- 3 bot types: AI, Grid Trading, DCA
- 12 exchanges supported via CCXT
- Telegram bot for monitoring
- Walk-forward validation with 63%+ accuracy

### Why it fits
Placed in the "Financial Data and Trading" section alongside backtrader, alpaca-trade-api, and other trading tools. DeepAlpha adds an ML-focused crypto trading framework to this section.

Thank you for maintaining this great resource!