### PR TITLE
Add Wickra to Financial Data and Trading

### DIFF
--- a/README.md
+++ b/README.md
@@ -975,6 +975,7 @@ Tutorial on using cvxpy: [1](https://calmcode.io/cvxpy-one/the-stigler-diet.html
 [yfinance](https://github.com/ranaroussi/yfinance) - Read stock data from Yahoo Finance.  
 [findatapy](https://github.com/cuemacro/findatapy) - Read stock data from various sources.  
 [ta](https://github.com/bukosabino/ta) - Technical analysis library.  
+[Wickra](https://github.com/wickra-lib/wickra) - Streaming-first technical analysis: 514 incremental (O(1)/tick) indicators over a Rust core, pip install wickra.  
 [backtrader](https://github.com/mementum/backtrader) - Backtesting for trading strategies.  
 [surpriver](https://github.com/tradytics/surpriver) - Find high moving stocks before they move using anomaly detection and machine learning.  
 [ffn](https://github.com/pmorissette/ffn) - Financial functions.  


### PR DESCRIPTION
Adds Wickra to the Financial Data and Trading section, next to ta.

Wickra is an open-source (MIT OR Apache-2.0) technical-analysis library with a Rust core and a Python package (pip install wickra - precompiled wheels, no system dependencies).

Highlights:
- 514 indicators across 24 families (candlesticks, patterns, volume, volatility, microstructure, risk/performance, ...), every one O(1) per tick.
- Same code path for batch backtests and live tick-by-tick streaming; batch == streaming is bit-exact and fully test-covered.
- Much faster than recompute-on-every-tick libraries for online/live use.
- Also usable from Node.js, WebAssembly, Rust and a C ABI.
- MIT OR Apache-2.0.

Repo: https://github.com/wickra-lib/wickra · Docs: https://docs.wickra.org
